### PR TITLE
Add Cache Control header implementation.

### DIFF
--- a/src/headers.ts
+++ b/src/headers.ts
@@ -2,5 +2,6 @@ export { ContentDispositionInit, ContentDisposition } from './lib/content-dispos
 export { ContentTypeInit, ContentType } from './lib/content-type.js';
 export { CookieInit, Cookie } from './lib/cookie.js';
 export { SetCookieInit, SetCookie } from './lib/set-cookie.js';
+export { CacheControlInit, CacheControl } from './lib/cache-control.js';
 
 export { SuperHeaders as default, SuperHeadersInit, SuperHeaders } from './lib/super-headers.js';

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,7 +1,7 @@
+export { CacheControlInit, CacheControl } from './lib/cache-control.js';
 export { ContentDispositionInit, ContentDisposition } from './lib/content-disposition.js';
 export { ContentTypeInit, ContentType } from './lib/content-type.js';
 export { CookieInit, Cookie } from './lib/cookie.js';
 export { SetCookieInit, SetCookie } from './lib/set-cookie.js';
-export { CacheControlInit, CacheControl } from './lib/cache-control.js';
 
 export { SuperHeaders as default, SuperHeadersInit, SuperHeaders } from './lib/super-headers.js';

--- a/src/lib/cache-control.spec.ts
+++ b/src/lib/cache-control.spec.ts
@@ -1,5 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+
 import { CacheControl } from './cache-control.js';
 
 describe('CacheControl', () => {

--- a/src/lib/cache-control.spec.ts
+++ b/src/lib/cache-control.spec.ts
@@ -1,0 +1,54 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { CacheControl } from './cache-control.js';
+
+describe('CacheControl', () => {
+  it('initializes with an empty string', () => {
+    let header = new CacheControl('');
+    assert.equal(header.maxAge, undefined);
+    assert.equal(header.public, undefined);
+    assert.equal(`${header}`, '');
+  });
+  it('initializes with a string', () => {
+    let header = new CacheControl('public, max-age=3600, s-maxage=3600');
+    assert.equal(header.maxAge, 3600);
+    assert.equal(header.sMaxage, 3600);
+    assert.equal(header.public, true);
+  });
+  it('initializes with an object', () => {
+    let header = new CacheControl({ public: true, maxAge: 3600, sMaxage: 3600 });
+    assert.equal(header.maxAge, 3600);
+    assert.equal(header.sMaxage, 3600);
+    assert.equal(header.public, true);
+  });
+  it('initializes with another CacheControl', () => {
+    let header = new CacheControl(new CacheControl('public, max-age=3600, s-maxage=3600'));
+    assert.equal(header.maxAge, 3600);
+    assert.equal(header.sMaxage, 3600);
+    assert.equal(header.public, true);
+  });
+  it('handles whitespace in initial value', () => {
+    let header = new CacheControl(' public , max-age = 3600, s-maxage=3600 ');
+    assert.equal(header.maxAge, 3600);
+    assert.equal(header.sMaxage, 3600);
+    assert.equal(header.public, true);
+  });
+  it('sets and gets attributes', () => {
+    let header = new CacheControl('');
+    header.maxAge = 3600;
+    header.sMaxage = 3600;
+    header.public = true;
+    assert.equal(header.maxAge, 3600);
+    assert.equal(header.sMaxage, 3600);
+    assert.equal(header.public, true);
+  });
+  it('converts to a string properly', () => {
+    let header = new CacheControl('public, max-age=3600, s-maxage=3600');
+    assert.equal(header.toString(), 'public, max-age=3600, s-maxage=3600');
+  });
+  it('sets numerical values to 0 instead of omitting them', () => {
+    let header = new CacheControl();
+    header.maxAge = 0;
+    assert.equal(header.toString(), 'max-age=0');
+  });
+});

--- a/src/lib/cache-control.ts
+++ b/src/lib/cache-control.ts
@@ -1,0 +1,308 @@
+import { HeaderValue } from './header-value.js';
+import { parseParams } from './param-values.js';
+
+// Taken from https://github.com/jjenzz/pretty-cache-header by jjenzz
+// License: MIT https://github.com/jjenzz/pretty-cache-header/blob/main/LICENSE
+export type CacheControlInit = {
+  /**
+   * The `max-age=N` **request directive** indicates that the client allows a stored response that
+   * is generated on the origin server within _N_ seconds — where _N_ may be any non-negative
+   * integer (including `0`).
+   *
+   * The `max-age=N` **response directive** indicates that the response remains
+   * [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age)
+   * until _N_ seconds after the response is generated.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-age
+   */
+  maxAge?: number;
+  /**
+   * The `max-stale=N` **request directive** indicates that the client allows a stored response
+   * that is [stale](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age)
+   * within _N_ seconds.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#max-stale
+   */
+  maxStale?: number;
+  /**
+   * The `min-fresh=N` **request directive** indicates that the client allows a stored response
+   * that is [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age)
+   * for at least _N_ seconds.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#min-fresh
+   */
+  minFresh?: number;
+  /**
+   * The `s-maxage` **response directive** also indicates how long the response is
+   * [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age) for (similar to `max-age`) —
+   * but it is specific to shared caches, and they will ignore `max-age` when it is present.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#s-maxage
+   */
+  sMaxage?: number;
+  /**
+   * The `no-cache` **request directive** asks caches to validate the response with the origin
+   * server before reuse. If you want caches to always check for content updates while reusing
+   * stored content, `no-cache` is the directive to use.
+   *
+   * The `no-cache` **response directive** indicates that the response can be stored in caches, but
+   * the response must be validated with the origin server before each reuse, even when the cache
+   * is disconnected from the origin server.
+   *
+   * `no-cache` allows clients to request the most up-to-date response even if the cache has a
+   * [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age)
+   * response.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-cache
+   */
+  noCache?: true;
+  /**
+   * The `no-store` **request directive** allows a client to request that caches refrain from
+   * storing the request and corresponding response — even if the origin server's response could
+   * be stored.
+   *
+   * The `no-store` **response directive** indicates that any caches of any kind (private or shared)
+   * should not store this response.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-store
+   */
+  noStore?: true;
+  /**
+   * `no-transform` indicates that any intermediary (regardless of whether it implements a cache)
+   * shouldn't transform the response contents.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#no-transform
+   */
+  noTransform?: true;
+  /**
+   * The client indicates that cache should obtain an already-cached response. If a cache has
+   * stored a response, it's reused.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#only-if-cached
+   */
+  onlyIfCached?: true;
+  /**
+   * The `must-revalidate` **response directive** indicates that the response can be stored in
+   * caches and can be reused while [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age).
+   * If the response becomes [stale](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age),
+   * it must be validated with the origin server before reuse.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#must-revalidate
+   */
+  mustRevalidate?: true;
+  /**
+   * The `proxy-revalidate` **response directive** is the equivalent of `must-revalidate`, but
+   * specifically for shared caches only.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#proxy-revalidate
+   */
+  proxyRevalidate?: true;
+  /**
+   * The `must-understand` **response directive** indicates that a cache should store the response
+   * only if it understands the requirements for caching based on status code.
+   *
+   * `must-understand` should be coupled with `no-store` for fallback behavior.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#must-understand
+   */
+  mustUnderstand?: true;
+  /**
+   * The `private` **response directive** indicates that the response can be stored only in a
+   * private cache (e.g. local caches in browsers).
+   *
+   * You should add the `private` directive for user-personalized content, especially for responses
+   * received after login and for sessions managed via cookies.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#private
+   */
+  private?: true;
+  /**
+   * The `public` **response directive** indicates that the response can be stored in a shared
+   * cache. Responses for requests with `Authorization` header fields must not be stored in a
+   * shared cache; however, the `public` directive will cause such responses to be stored in a
+   * shared cache.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#public
+   */
+  public?: true;
+  /**
+   * The `immutable` **response directive** indicates that the response will not be updated while
+   * it's [fresh](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age).
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#public
+   */
+  immutable?: true;
+  /**
+   * The `stale-while-revalidate` **response directive** indicates that the cache could reuse a
+   * stale response while it revalidates it to a cache.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-while-revalidate
+   */
+  staleWhileRevalidate?: number;
+  /**
+   * The `stale-if-error` **response directive** indicates that the cache can reuse a
+   * [stale response](https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#fresh_and_stale_based_on_age)
+   * when an upstream server generates an error, or when the error is generated locally. Here, an
+   * error is considered any response with a status code of 500, 502, 503, or 504.
+   *
+   * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#stale-if-error
+   */
+  staleIfError?: number;
+};
+
+export class CacheControl implements HeaderValue, CacheControlInit {
+  maxAge?: number;
+  maxStale?: number;
+  minFresh?: number;
+  sMaxage?: number;
+  noCache?: true;
+  noStore?: true;
+  noTransform?: true;
+  onlyIfCached?: true;
+  mustRevalidate?: true;
+  proxyRevalidate?: true;
+  mustUnderstand?: true;
+  private?: true;
+  public?: true;
+  immutable?: true;
+  staleWhileRevalidate?: number;
+  staleIfError?: number;
+
+  /**
+   * The value of a `Cache-Control` HTTP header.
+   *
+   * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)
+   */
+  constructor(init?: string | CacheControlInit) {
+    if (init) {
+      if (typeof init === 'string') {
+        let params = parseParams(init, ',');
+        if (params.length > 0) {
+          for (let [name, value] of params) {
+            switch (name) {
+              case 'max-age':
+                this.maxAge = Number(value);
+                break;
+              case 'max-stale':
+                this.maxStale = Number(value);
+                break;
+              case 'min-fresh':
+                this.minFresh = Number(value);
+                break;
+              case 's-maxage':
+                this.sMaxage = Number(value);
+                break;
+              case 'no-cache':
+                this.noCache = true;
+                break;
+              case 'no-store':
+                this.noStore = true;
+                break;
+              case 'no-transform':
+                this.noTransform = true;
+                break;
+              case 'only-if-cached':
+                this.onlyIfCached = true;
+                break;
+              case 'must-revalidate':
+                this.mustRevalidate = true;
+                break;
+              case 'proxy-revalidate':
+                this.proxyRevalidate = true;
+                break;
+              case 'must-understand':
+                this.mustUnderstand = true;
+                break;
+              case 'private':
+                this.private = true;
+                break;
+              case 'public':
+                this.public = true;
+                break;
+              case 'immutable':
+                this.immutable = true;
+                break;
+              case 'stale-while-revalidate':
+                this.staleWhileRevalidate = Number(value);
+                break;
+              case 'stale-if-error':
+                this.staleIfError = Number(value);
+                break;
+            }
+          }
+        }
+      } else {
+        this.maxAge = init.maxAge;
+        this.maxStale = init.maxStale;
+        this.minFresh = init.minFresh;
+        this.sMaxage = init.sMaxage;
+        this.noCache = init.noCache;
+        this.noStore = init.noStore;
+        this.noTransform = init.noTransform;
+        this.onlyIfCached = init.onlyIfCached;
+        this.mustRevalidate = init.mustRevalidate;
+        this.proxyRevalidate = init.proxyRevalidate;
+        this.mustUnderstand = init.mustUnderstand;
+        this.private = init.private;
+        this.public = init.public;
+        this.immutable = init.immutable;
+        this.staleWhileRevalidate = init.staleWhileRevalidate;
+        this.staleIfError = init.staleIfError;
+      }
+    }
+  }
+
+  toString(): string {
+    let parts = [];
+
+    if (this.public) {
+      parts.push('public');
+    }
+    if (this.private) {
+      parts.push('private');
+    }
+    if (typeof this.maxAge === 'number') {
+      parts.push(`max-age=${this.maxAge}`);
+    }
+    if (typeof this.sMaxage === 'number') {
+      parts.push(`s-maxage=${this.sMaxage}`);
+    }
+    if (this.noCache) {
+      parts.push('no-cache');
+    }
+    if (this.noStore) {
+      parts.push('no-store');
+    }
+    if (this.noTransform) {
+      parts.push('no-transform');
+    }
+    if (this.onlyIfCached) {
+      parts.push('only-if-cached');
+    }
+    if (this.mustRevalidate) {
+      parts.push('must-revalidate');
+    }
+    if (this.proxyRevalidate) {
+      parts.push('proxy-revalidate');
+    }
+    if (this.mustUnderstand) {
+      parts.push('must-understand');
+    }
+    if (this.immutable) {
+      parts.push('immutable');
+    }
+    if (typeof this.staleWhileRevalidate === 'number') {
+      parts.push(`stale-while-revalidate=${this.staleWhileRevalidate}`);
+    }
+    if (typeof this.staleIfError === 'number') {
+      parts.push(`stale-if-error=${this.staleIfError}`);
+    }
+    if (typeof this.maxStale === 'number') {
+      parts.push(`max-stale=${this.maxStale}`);
+    }
+    if (typeof this.minFresh === 'number') {
+      parts.push(`min-fresh=${this.minFresh}`);
+    }
+    return parts.join(', ');
+  }
+}

--- a/src/lib/cache-control.ts
+++ b/src/lib/cache-control.ts
@@ -303,6 +303,7 @@ export class CacheControl implements HeaderValue, CacheControlInit {
     if (typeof this.minFresh === 'number') {
       parts.push(`min-fresh=${this.minFresh}`);
     }
+
     return parts.join(', ');
   }
 }

--- a/src/lib/param-values.ts
+++ b/src/lib/param-values.ts
@@ -1,5 +1,11 @@
-export function parseParams(input: string): [string, string | undefined][] {
+export function parseParams(
+  input: string,
+  delimiter: ';' | ',' = ';',
+): [string, string | undefined][] {
   let regex = /(?:^|;)\s*([^=;\s]+)(\s*=\s*(?:"((?:[^"\\]|\\.)*)"|((?:[^;]|\\\;)+))?)?/g;
+  if (delimiter === ',') {
+    regex = /(?:^|,)\s*([^=,\s]+)(\s*=\s*(?:"((?:[^"\\]|\\.)*)"|((?:[^,]|\\\,)+))?)?/g;
+  }
   let params: [string, string | undefined][] = [];
 
   let match;

--- a/src/lib/super-headers.spec.ts
+++ b/src/lib/super-headers.spec.ts
@@ -5,6 +5,7 @@ import { ContentDisposition } from './content-disposition.js';
 import { ContentType } from './content-type.js';
 import { Cookie } from './cookie.js';
 import { SuperHeaders } from './super-headers.js';
+import { CacheControl } from './cache-control.js';
 
 describe('SuperHeaders', () => {
   it('is an instance of Headers', () => {
@@ -53,6 +54,11 @@ describe('SuperHeaders', () => {
     let original = new Headers({ 'Content-Type': 'text/plain' });
     let headers = new SuperHeaders(original);
     assert.equal(headers.get('Content-Type'), 'text/plain');
+  });
+
+  it('initializes with a CacheControlInit', () => {
+    let headers = new SuperHeaders({ cacheControl: 'public, max-age=3600' });
+    assert.equal(headers.get('Cache-Control'), 'public, max-age=3600');
   });
 
   it('initializes with a ContentDispositionInit', () => {
@@ -190,6 +196,20 @@ describe('SuperHeaders', () => {
       assert.equal(headers.get('Age'), '42');
     });
 
+    it('handles Cache-Control header', () => {
+      let headers = new SuperHeaders();
+      headers.cacheControl = 'public, max-age=3600';
+
+      assert.ok(headers.cacheControl instanceof CacheControl);
+      assert.equal(headers.cacheControl.toString(), 'public, max-age=3600');
+
+      headers.cacheControl.maxAge = 1800;
+      assert.equal(headers.get('Cache-Control'), 'public, max-age=1800');
+
+      headers.cacheControl = { noCache: true, noStore: true };
+      assert.equal(headers.get('Cache-Control'), 'no-cache, no-store');
+    });
+
     it('handles Content-Disposition header', () => {
       let headers = new SuperHeaders();
       headers.contentDisposition = 'attachment; filename="example.txt"';
@@ -285,6 +305,9 @@ describe('SuperHeaders', () => {
 
     it('creates empty header objects when accessed', () => {
       let headers = new SuperHeaders();
+
+      assert.ok(headers.cacheControl instanceof CacheControl);
+      assert.equal(headers.cacheControl.toString(), '');
 
       assert.ok(headers.contentDisposition instanceof ContentDisposition);
       assert.equal(headers.contentDisposition.toString(), '');

--- a/src/lib/super-headers.ts
+++ b/src/lib/super-headers.ts
@@ -1,3 +1,4 @@
+import { CacheControl, CacheControlInit } from './cache-control.js';
 import { ContentDispositionInit, ContentDisposition } from './content-disposition.js';
 import { ContentTypeInit, ContentType } from './content-type.js';
 import { CookieInit, Cookie } from './cookie.js';
@@ -21,6 +22,7 @@ interface SuperHeadersPropertyInit {
   ifUnmodifiedSince?: string | Date;
   lastModified?: string | Date;
   setCookie?: string | (string | SetCookieInit)[];
+  cacheControl?: string | CacheControlInit;
 }
 
 export type SuperHeadersInit =
@@ -193,6 +195,14 @@ export class SuperHeaders extends Headers implements Iterable<[string, string]> 
 
   set age(value: string | number) {
     this.#map.set('age', value);
+  }
+
+  get cacheControl(): CacheControl {
+    return this.#getHeaderValue('cache-control', CacheControl);
+  }
+
+  set cacheControl(value: string | CacheControlInit) {
+    this.#setHeaderValue('cache-control', CacheControl, value);
   }
 
   get contentDisposition(): ContentDisposition {


### PR DESCRIPTION
Implements the Cache Control header, as described in #6. It uses the same interface and JSDoc comments from https://github.com/jjenzz/pretty-cache-header, but does not implement time strings and instead just accepts numerical seconds. Parsing the time strings would require an external dependency, and I don't feel comfortable adding the very first dependency. 😅 

I intentionally made it so it doesn't filter any directives based on other directives, like `public` vs `private`. 

`Cache-Control` is more flexible than the other headers that have been implemented, so the tests feel surprisingly sparse. If there are more tests you want me to implement, I'm happy to do it.

Closes #6 