### PR TITLE
Add Accept-Language header implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ import Headers from '@mjackson/headers';
 
 let headers = new Headers();
 
+// Accept-Language
+
+headers.acceptLanguage = 'en-US,en;q=0.9';
+
+console.log(headers.acceptLanguage.languages); // [ 'en-US', 'en' ]
+console.log(headers.acceptLanguage.entries());
+// [Map Entries] { [ 'en-US', 1 ], [ 'en', 0.9 ] }
+
 // Content-Type
 headers.contentType = 'application/json; charset=utf-8';
 
@@ -155,6 +163,7 @@ All individual header classes may be initialized with either a) the string value
 
 The following headers are currently supported:
 
+- [`Accept-Language`](#accept-language)
 - [`Cache-Control`](#cache-control)
 - [`Content-Disposition`](#content-disposition)
 - [`Content-Type`](#content-type)
@@ -162,6 +171,24 @@ The following headers are currently supported:
 - [`Set-Cookie`](#set-cookie)
 
 If you need support for a header that isn't listed here, please [send a PR](https://github.com/mjackson/headers/pulls)! The goal is to have first-class support for all common HTTP headers.
+
+### Accept-Language
+
+```ts
+let header = new AcceptLanguage('en-US,en;q=0.9');
+header.get('en-US'); // 1
+header.set('en-US', 0.8);
+header.delete('en-US');
+header.has('en'); // true
+
+// Iterate over language/quality pairs
+for (let [language, quality] of header) {
+  // ...
+}
+
+let header = new AcceptLanguage(['en-US', ['en', 0.9]]);
+let header = new AcceptLanguage({ 'en-US': 1, en: 0.9 });
+```
 
 ### Cache-Control
 

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,3 +1,4 @@
+export { AcceptLanguageInit, AcceptLanguage } from './lib/accept-language.js';
 export { CacheControlInit, CacheControl } from './lib/cache-control.js';
 export { ContentDispositionInit, ContentDisposition } from './lib/content-disposition.js';
 export { ContentTypeInit, ContentType } from './lib/content-type.js';

--- a/src/lib/accept-language.spec.ts
+++ b/src/lib/accept-language.spec.ts
@@ -1,0 +1,138 @@
+import * as assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { AcceptLanguage } from './accept-language.js';
+
+describe('Accept-Language', () => {
+  it('initializes with an empty string', () => {
+    let header = new AcceptLanguage('');
+    assert.equal(header.size, 0);
+  });
+
+  it('initializes with a string', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    assert.equal(header.get('en-US'), 1);
+    assert.equal(header.get('en'), 0.9);
+  });
+
+  it('initializes with an array', () => {
+    let header = new AcceptLanguage(['en-US', ['en', 0.9], ['fi', undefined], ['fi-FI']]);
+    assert.equal(header.get('en-US'), 1);
+    assert.equal(header.get('en'), 0.9);
+    assert.equal(header.get('fi'), 1);
+    assert.equal(header.get('fi-FI'), 1);
+  });
+
+  it('initializes with an object', () => {
+    let header = new AcceptLanguage({ 'en-US': undefined, en: 0.9 });
+    assert.equal(header.get('en-US'), 1);
+    assert.equal(header.get('en'), 0.9);
+  });
+
+  it('initializes with another Accept-Language', () => {
+    let header = new AcceptLanguage(new AcceptLanguage('en-US,en;q=0.9'));
+    assert.equal(header.get('en-US'), 1);
+    assert.equal(header.get('en'), 0.9);
+  });
+
+  it('handles whitespace in initial value', () => {
+    let header = new AcceptLanguage(' en-US ,  en;q=  0.9  ');
+    assert.equal(header.get('en-US'), 1);
+    assert.equal(header.get('en'), 0.9);
+  });
+
+  it('sets and gets languages', () => {
+    let header = new AcceptLanguage('');
+    header.set('en', 0.9);
+    assert.equal(header.get('en'), 0.9);
+  });
+
+  it('deletes languages', () => {
+    let header = new AcceptLanguage('en-US');
+    assert.equal(header.delete('en-US'), true);
+    assert.equal(header.delete('en'), false);
+    assert.equal(header.get('en-US'), undefined);
+  });
+
+  it('checks if language exists', () => {
+    let header = new AcceptLanguage('en-US');
+    assert.equal(header.has('en-US'), true);
+    assert.equal(header.has('fs'), false);
+  });
+
+  it('clears all languages', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    header.clear();
+    assert.equal(header.size, 0);
+  });
+
+  it('iterates over entries', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    let entries = Array.from(header.entries());
+    assert.deepEqual(entries, [
+      ['en-US', 1],
+      ['en', 0.9],
+    ]);
+  });
+
+  it('gets all languages', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    assert.deepEqual(header.languages, ['en-US', 'en']);
+  });
+
+  it('gets all qualities', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    assert.deepEqual(header.qualities, [1, 0.9]);
+  });
+
+  it('uses forEach correctly', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    let result: [string, number][] = [];
+    header.forEach((language, quality) => {
+      result.push([language, quality]);
+    });
+    assert.deepEqual(result, [
+      ['en-US', 1],
+      ['en', 0.9],
+    ]);
+  });
+
+  it('returns correct size', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    assert.equal(header.size, 2);
+  });
+
+  it('converts to string correctly', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    assert.equal(header.toString(), 'en-US,en;q=0.9');
+  });
+
+  it('is directly iterable', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    let entries = Array.from(header);
+    assert.deepEqual(entries, [
+      ['en-US', 1],
+      ['en', 0.9],
+    ]);
+  });
+
+  it('handles setting empty quality values', () => {
+    let header = new AcceptLanguage('');
+    header.set('en-US');
+    assert.equal(header.get('en-US'), 1);
+    assert.equal(header.toString(), 'en-US');
+  });
+
+  it('overwrites existing quality values', () => {
+    let header = new AcceptLanguage('en;q=0.9');
+    header.set('en', 1);
+    assert.equal(header.get('en'), 1);
+  });
+
+  it('handles setting wildcard value', () => {
+    let header = new AcceptLanguage('');
+    header.set('*');
+    assert.equal(header.get('*'), 1);
+    assert.equal(header.toString(), '*');
+  });
+});

--- a/src/lib/accept-language.spec.ts
+++ b/src/lib/accept-language.spec.ts
@@ -135,4 +135,20 @@ describe('Accept-Language', () => {
     assert.equal(header.get('*'), 1);
     assert.equal(header.toString(), '*');
   });
+
+  it('sorts initial value', () => {
+    let header = new AcceptLanguage('en;q=0.9,en-US');
+    assert.equal(header.toString(), 'en-US,en;q=0.9');
+    assert.deepEqual(header.languages, ['en-US', 'en']);
+  });
+
+  it('sorts updated value', () => {
+    let header = new AcceptLanguage('en-US,en;q=0.9');
+    header.set('fi');
+    assert.equal(header.toString(), 'en-US,fi,en;q=0.9');
+    assert.deepEqual(header.languages, ['en-US', 'fi', 'en']);
+    header.set('en-US', 0.8);
+    assert.equal(header.toString(), 'fi,en;q=0.9,en-US;q=0.8');
+    assert.deepEqual(header.languages, ['fi', 'en', 'en-US']);
+  });
 });

--- a/src/lib/accept-language.ts
+++ b/src/lib/accept-language.ts
@@ -1,0 +1,122 @@
+import { HeaderValue } from './header-value.js';
+import { parseParams } from './param-values.js';
+import { isIterable } from './utils.js';
+
+export type AcceptLanguageInit =
+  | Iterable<string | [string] | [string, number | undefined]>
+  | Record<string, number | undefined>;
+
+/**
+ * The value of a `Accept-Language` HTTP header.
+ *
+ * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language)
+ */
+export class AcceptLanguage implements HeaderValue, Iterable<[string, number]> {
+  #map: Map<string, number>;
+
+  constructor(init?: string | AcceptLanguageInit) {
+    this.#map = new Map();
+    if (init) {
+      if (typeof init === 'string') {
+        let params = parseParams(init, ',');
+        for (let [language, quality] of params) {
+          if (typeof quality === 'string') {
+            language = language.slice(0, -2).trim();
+          } else {
+            quality = '1';
+          }
+          this.#map.set(language, Number(quality));
+        }
+      } else if (isIterable(init)) {
+        for (let language of init) {
+          let quality;
+          if (Array.isArray(language)) {
+            [language, quality] = language;
+          }
+          this.#map.set(language, quality ?? 1);
+        }
+      } else {
+        for (let language in init) {
+          if (Object.prototype.hasOwnProperty.call(init, language)) {
+            this.#map.set(language, init[language] ?? 1);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Gets the quality of a language with the given locale identifier from the `Accept-Language` header.
+   */
+  get(language: string): number | undefined {
+    return this.#map.get(language);
+  }
+
+  /**
+   * Sets a language with the given quality in the `Accept-Language` header.
+   */
+  set(language: string, quality = 1): void {
+    this.#map.set(language, quality);
+  }
+
+  /**
+   * Removes a language with the given locale identifier from the `Accept-Language` header.
+   */
+  delete(language: string): boolean {
+    return this.#map.delete(language);
+  }
+
+  /**
+   * True if a language with the given locale identifier in the `Accept-Language` header.
+   */
+  has(language: string): boolean {
+    return this.#map.has(language);
+  }
+
+  /**
+   * Removes all languages from the `Accept-Language` header.
+   */
+  clear(): void {
+    this.#map.clear();
+  }
+
+  entries(): IterableIterator<[string, number]> {
+    return this.#map.entries();
+  }
+
+  get languages(): string[] {
+    return Array.from(this.#map.keys());
+  }
+
+  get qualities(): number[] {
+    return Array.from(this.#map.values());
+  }
+
+  [Symbol.iterator](): IterableIterator<[string, number]> {
+    return this.entries();
+  }
+
+  forEach(
+    callback: (language: string, quality: number, map: Map<string, number>) => void,
+    thisArg?: any,
+  ): void {
+    this.#map.forEach((quality, language, map) => callback(language, quality, map), thisArg);
+  }
+
+  /**
+   * The number of languages in the `Accept-Language` header.
+   */
+  get size(): number {
+    return this.#map.size;
+  }
+
+  toString(): string {
+    let pairs: string[] = [];
+
+    for (let [language, quality] of this.#map) {
+      pairs.push(`${language}${quality === 1 ? '' : `;q=${quality}`}`);
+    }
+
+    return pairs.join(',');
+  }
+}

--- a/src/lib/accept-language.ts
+++ b/src/lib/accept-language.ts
@@ -42,7 +42,12 @@ export class AcceptLanguage implements HeaderValue, Iterable<[string, number]> {
           }
         }
       }
+      this.#sort();
     }
+  }
+
+  #sort() {
+    this.#map = new Map([...this.#map].sort(([, a], [, b]) => b - a));
   }
 
   /**
@@ -57,6 +62,7 @@ export class AcceptLanguage implements HeaderValue, Iterable<[string, number]> {
    */
   set(language: string, quality = 1): void {
     this.#map.set(language, quality);
+    this.#sort();
   }
 
   /**

--- a/src/lib/super-headers.spec.ts
+++ b/src/lib/super-headers.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import { AcceptLanguage } from './accept-language.js';
 import { CacheControl } from './cache-control.js';
 import { ContentDisposition } from './content-disposition.js';
 import { ContentType } from './content-type.js';
@@ -54,6 +55,13 @@ describe('SuperHeaders', () => {
     let original = new Headers({ 'Content-Type': 'text/plain' });
     let headers = new SuperHeaders(original);
     assert.equal(headers.get('Content-Type'), 'text/plain');
+  });
+
+  it('initializes with a AcceptLanguageInit', () => {
+    let headers = new SuperHeaders({
+      acceptLanguage: { 'en-US': 1, en: 0.9 },
+    });
+    assert.equal(headers.get('Accept-Language'), 'en-US,en;q=0.9');
   });
 
   it('initializes with a CacheControlInit', () => {
@@ -196,6 +204,20 @@ describe('SuperHeaders', () => {
       assert.equal(headers.get('Age'), '42');
     });
 
+    it('handles Accept-Language header', () => {
+      let headers = new SuperHeaders();
+      headers.acceptLanguage = 'en-US,en;q=0.9';
+
+      assert.ok(headers.acceptLanguage instanceof AcceptLanguage);
+      assert.deepStrictEqual(headers.acceptLanguage.languages, ['en-US', 'en']);
+
+      headers.acceptLanguage.set('en', 0.8);
+      assert.equal(headers.get('Accept-Language'), 'en-US,en;q=0.8');
+
+      headers.acceptLanguage = { 'fi-FI': 1, fi: 0.9 };
+      assert.equal(headers.get('Accept-Language'), 'fi-FI,fi;q=0.9');
+    });
+
     it('handles Cache-Control header', () => {
       let headers = new SuperHeaders();
       headers.cacheControl = 'public, max-age=3600';
@@ -305,6 +327,9 @@ describe('SuperHeaders', () => {
 
     it('creates empty header objects when accessed', () => {
       let headers = new SuperHeaders();
+
+      assert.ok(headers.acceptLanguage instanceof AcceptLanguage);
+      assert.equal(headers.acceptLanguage.toString(), '');
 
       assert.ok(headers.cacheControl instanceof CacheControl);
       assert.equal(headers.cacheControl.toString(), '');

--- a/src/lib/super-headers.ts
+++ b/src/lib/super-headers.ts
@@ -1,3 +1,4 @@
+import { AcceptLanguageInit, AcceptLanguage } from './accept-language.js';
 import { CacheControlInit, CacheControl } from './cache-control.js';
 import { ContentDispositionInit, ContentDisposition } from './content-disposition.js';
 import { ContentTypeInit, ContentType } from './content-type.js';
@@ -11,6 +12,7 @@ const CRLF = '\r\n';
 const SetCookieKey = 'set-cookie';
 
 interface SuperHeadersPropertyInit {
+  acceptLanguage?: AcceptLanguageInit;
   age?: string | number;
   cacheControl?: string | CacheControlInit;
   contentDisposition?: string | ContentDispositionInit;
@@ -188,6 +190,14 @@ export class SuperHeaders extends Headers implements Iterable<[string, string]> 
   }
 
   // Header-specific getters and setters
+
+  get acceptLanguage(): AcceptLanguage {
+    return this.#getHeaderValue('accept-language', AcceptLanguage);
+  }
+
+  set acceptLanguage(value: string | AcceptLanguageInit) {
+    this.#setHeaderValue('accept-language', AcceptLanguage, value);
+  }
 
   get age(): number | undefined {
     return this.#getNumberValue('age');


### PR DESCRIPTION
This PR adds an implementation of the `Accept-Language` header, modeled after the `Cookie` header interface.

Unlike the `Cookie` header's `header.names()` and `header.values()` iterators, this implementation provides property getters for `header.languages: string[]` and `header.qualities: number[]`, as well as an `header.entries()` iterator.

For example, this allows direct use of [Intl.LocaleMatcher.match](https://github.com/tc39/proposal-intl-localematcher) like so:

```js
match(headers.acceptLanguage.languages, availableLocales, defaultLocale);
```